### PR TITLE
Add Datadog RUM + cross-env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,8 @@
     "": {
       "version": "0.1.0",
       "dependencies": {
+        "@datadog/browser-rum": "^2.7.2",
+        "dotenv": "^4.0.0",
         "history": "^4.6.3",
         "marked": "^0.3.6",
         "prop-types": "^15.5.10",
@@ -33,6 +35,33 @@
       "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/@datadog/browser-core": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-2.7.2.tgz",
+      "integrity": "sha512-DBylRuLLt+ro2nO51s2xNPY7q/oZFL3MTNziXG2tWrQ01o2TiXDhXPriTF/7dj10vnPGYwb2g38x654Psja0MA==",
+      "dependencies": {
+        "tslib": "^1.10.0"
+      }
+    },
+    "node_modules/@datadog/browser-rum": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-2.7.2.tgz",
+      "integrity": "sha512-nOpO+ElEb6Oj2QU2jMqjTPyVeWWs/xRwEZvTpQQzaY9s/cp9kFet97h8y0TUI67h3lkBjPc5/ueIwT/q5thNzw==",
+      "dependencies": {
+        "@datadog/browser-core": "2.7.2",
+        "@datadog/browser-rum-core": "2.7.2",
+        "tslib": "^1.10.0"
+      }
+    },
+    "node_modules/@datadog/browser-rum-core": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-2.7.2.tgz",
+      "integrity": "sha512-6c9mDz0BiJaBd6bBEd4UtgLGzsf1th+7bQUhX8S7+M/acYOBdFbJr66SnaJYwghH2ABWxf5kKu6Mf6bqZ5GZnw==",
+      "dependencies": {
+        "@datadog/browser-core": "2.7.2",
+        "tslib": "^1.10.0"
       }
     },
     "node_modules/abab": {
@@ -3517,7 +3546,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
       "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=",
-      "dev": true,
       "engines": {
         "node": ">=4.6.0"
       }
@@ -12873,6 +12901,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
     "node_modules/tty-browserify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
@@ -15316,6 +15349,33 @@
       "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "@datadog/browser-core": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-2.7.2.tgz",
+      "integrity": "sha512-DBylRuLLt+ro2nO51s2xNPY7q/oZFL3MTNziXG2tWrQ01o2TiXDhXPriTF/7dj10vnPGYwb2g38x654Psja0MA==",
+      "requires": {
+        "tslib": "^1.10.0"
+      }
+    },
+    "@datadog/browser-rum": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-2.7.2.tgz",
+      "integrity": "sha512-nOpO+ElEb6Oj2QU2jMqjTPyVeWWs/xRwEZvTpQQzaY9s/cp9kFet97h8y0TUI67h3lkBjPc5/ueIwT/q5thNzw==",
+      "requires": {
+        "@datadog/browser-core": "2.7.2",
+        "@datadog/browser-rum-core": "2.7.2",
+        "tslib": "^1.10.0"
+      }
+    },
+    "@datadog/browser-rum-core": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-2.7.2.tgz",
+      "integrity": "sha512-6c9mDz0BiJaBd6bBEd4UtgLGzsf1th+7bQUhX8S7+M/acYOBdFbJr66SnaJYwghH2ABWxf5kKu6Mf6bqZ5GZnw==",
+      "requires": {
+        "@datadog/browser-core": "2.7.2",
+        "tslib": "^1.10.0"
       }
     },
     "abab": {
@@ -18348,8 +18408,7 @@
     "dotenv": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
-      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=",
-      "dev": true
+      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
     },
     "dotenv-expand": {
       "version": "4.2.0",
@@ -26070,6 +26129,11 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
+    },
+    "tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "tty-browserify": {
       "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "react-scripts": "1.1.1"
   },
   "dependencies": {
+    "@datadog/browser-rum": "^2.7.2",
+    "dotenv": "^4.0.0",
     "history": "^4.6.3",
     "marked": "^0.3.6",
     "prop-types": "^15.5.10",

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,18 @@ import { store, history} from './store';
 import { Route, Switch } from 'react-router-dom';
 import { ConnectedRouter } from 'react-router-redux';
 
+import { datadogRum } from '@datadog/browser-rum';
+
 import App from './components/App';
+
+datadogRum.init({
+    applicationId: process.env.REACT_APP_ID,
+    clientToken: process.env.REACT_APP_CLIENT_TOKEN,
+    site: 'datadoghq.com',
+    service: 'Conduit',
+    sampleRate: 100,
+    trackInteractions: true
+});
 
 ReactDOM.render((
   <Provider store={store}>


### PR DESCRIPTION
## Description
Adding [Datadog RUM](https://docs.datadoghq.com/real_user_monitoring/) in `src/index.js`, and initializing it using [`cross-env`](https://www.npmjs.com/package/cross-env).

**Note about `cross-env`**: environment variables (in the `.env` file) must be prepended with the `REACT_APP_` prefix in order for `cross-env` to pass them in effectively.